### PR TITLE
Add temporary fix to limit image size

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -29,7 +29,9 @@ CONFIG_NRF_MODEM_LIB_ON_FAULT_APPLICATION_SPECIFIC=y
 
 # AT Host library - Used to send AT commands directy from an UART terminal and to allow
 #		    integration with nRF Connect for Desktop LTE Link monitor application.
-CONFIG_AT_HOST_LIBRARY=y
+# TODO: Disable for now - saves us some flash space until we further limit the image size
+# This saves us 0.27% of flash to squeak under our budget of 250k
+# CONFIG_AT_HOST_LIBRARY=y
 
 # Network
 CONFIG_NETWORKING=y


### PR DESCRIPTION
### Summary

We are pushing the limit on our image size; with the new metrics,
the build fails because we max out:

```
Error: Image size (0x68afc) + trailer (0x630) exceeds requested size 0x69000
```

As a temporary fix, disable the host AT
library (allows sending AT commands via the serial console),
which is not necessary for "production".

Currently investigating limiting the storage partition, which is
unnecessarily large.

### Test Plan

Built the image successfully.