### PR TITLE
Remove heartbeat debug trigger call

### DIFF
--- a/src/modules/debug_module.c
+++ b/src/modules/debug_module.c
@@ -289,8 +289,6 @@ static void add_location_metrics(uint8_t satellites, uint32_t search_time,
 	if (err) {
 		LOG_ERR("Failed updating GnssSatellitesTracked metric, error: %d", err);
 	}
-
-	memfault_metrics_heartbeat_debug_trigger();
 }
 
 static void memfault_handle_event(struct debug_msg_data *msg)


### PR DESCRIPTION
### Summary

A call to `memfault_metrics_heartbeat_debug_trigger()` is
being made when there are events from the location module.
This is not the intended use of heartbeats, so we are taking it
out with the goal of eventually asking Nordic to remove it
as well. Additionally, it has blown our data budget lately on the Wefault
fleet and may also do so for potential customers.

### Test Plan

Compiled successfully and then flashed a Thingy91.