### PR TITLE
Bump sdk version for new metric APIs

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -17,7 +17,7 @@ manifest:
     - name: memfault-firmware-sdk
       url: https://github.com/memfault/memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: "1.4.0"
+      revision: "1.4.3"
 
   self:
     path: firmware


### PR DESCRIPTION
### Summary

A quick fix to bump the memfault sdk version; build is failing
at the moment without new metric APIs. I had forgotten
that I was symlinking to my local memfault sdk version.