### PR TITLE
chore(rtt): Log to shell for one window RTT

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -116,4 +116,9 @@ CONFIG_UART_CONSOLE=n
 CONFIG_RTT_CONSOLE=y
 CONFIG_USE_SEGGER_RTT=y
 CONFIG_SHELL_BACKEND_RTT=y
+
+# Ensure backend uses shell for logging so that logging
+# output and console are available in the same window
+# instead of logs being separately viewed in a file via
+# RTT logger
 CONFIG_SHELL_LOG_BACKEND=y


### PR DESCRIPTION
### Summary

Previously, two windows were needed to send commands and get logs
from the project. Now, all that is needed is the opening of port 19021
after starting up JLinkRTTLogger.

```
JLinkRTTLogger -Device NRF9160_XXAA -RTTChannel 1 -if SWD -Speed 4000 ~/rtt.log
```

Then, in a separate window
```
nc localhost 19021
SEGGER J-Link V7.88j - Real time terminal output
SEGGER J-Link V12.0, SN=52004908
Process: JLinkRTTLoggerExe


rtt:~$ *** Booting nRF Connect SDK 8d78e28fb74c ***
rtt:~$ [00:00:00.272,125] <inf> mflt: Reset Reason, RESETREAS=0x10000
rtt:~$ [00:00:00.272,186] <inf> mflt: Reset Causes:
rtt:~$ [00:00:00.272,216] <inf> mflt:  Software
rtt:~$ [00:00:00.273,315] <inf> mflt: GNU Build ID: a1150da121d7e8e5ee4977317f6649a2a52d0b60
```

### Test Plan

Flashed thingy91.