### PR TITLE
Fix build failure if memfault not enabled

### DIFF
--- a/src/modules/sensor_module.c
+++ b/src/modules/sensor_module.c
@@ -25,7 +25,9 @@
 #include "events/sensor_module_event.h"
 #include "events/util_module_event.h"
 
+#if defined(CONFIG_MEMFAULT)
 #include "memfault/components.h"
+#endif
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sensor_module, CONFIG_SENSOR_MODULE_LOG_LEVEL);
@@ -262,6 +264,7 @@ static void battery_data_get(void)
 		return;
 	}
 
+#if defined(CONFIG_MEMFAULT)
 	memfault_metrics_heartbeat_set_unsigned(
 		MEMFAULT_METRICS_KEY(battery_soc_pct),
 		percentage
@@ -276,6 +279,7 @@ static void battery_data_get(void)
 		MEMFAULT_METRICS_KEY(battery_voltage_mv),
 		millivolts
 	);
+#endif
 
 	sensor_module_event = new_sensor_module_event();
 


### PR DESCRIPTION
### Summary

This version of the asset tracker is intended to be used with
memfault, but in case we apply some of these changes to upstream
asset tracker, we want it to work without memfault. We were missing
a wrapping of memfault apis in a check to see if the project was
configured with memfault.

### Test Plan

Compiled successfully without the memfault overlay.

----
Resolves: MFLT-12457