### PR TITLE
Switch to UART console instead of RTT

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -112,10 +112,12 @@ CONFIG_HW_ID_LIBRARY_SOURCE_IMEI=y
 
 # Configure shell & RTT
 CONFIG_SHELL=y
-CONFIG_UART_CONSOLE=n
-CONFIG_RTT_CONSOLE=y
-CONFIG_USE_SEGGER_RTT=y
-CONFIG_SHELL_BACKEND_RTT=y
+CONFIG_UART_CONSOLE=y
+CONFIG_RTT_CONSOLE=n
+CONFIG_USE_SEGGER_RTT=n
+CONFIG_SHELL_BACKEND_RTT=n
+
+CONFIG_LOG_DEFAULT_LEVEL=2
 
 # Ensure backend uses shell for logging so that logging
 # output and console are available in the same window


### PR DESCRIPTION
To use it, first flash the "connectivity bridge" fw to the nrf52:

1. toggle power switch to off
2. switch "swd switch" to nrf52, power switch to on, connect jlink
3. flash the
   `thingy91_nrf52_connectivity_bridge_2023-10-26_1fae141f.hex` using
   the connect-for-desktop "programmer" app
4. power switch to off, "swd switch" to nrf9160, power switch to on
5. connect USB micro b cable to computer

Flash this app to the 9160, which enables UART instead of RTT, and
connect your favorite serial terminal at 115200-8-n-1.

Note that I dropped the default log level a notch (from 3=debug to
2=info) because otherwise the app was out of space. Enabling UART + that
change still has us a little more breathing room than before (373896,
98.15% full).
