### PR TITLE
Update to Memfault SDK 1.5.0-rc1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -17,7 +17,7 @@ manifest:
     - name: memfault-firmware-sdk
       url: https://github.com/memfault/memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: "1.4.3"
+      revision: "release/1.5.0"
 
   self:
     path: firmware


### PR DESCRIPTION
This is a branch I pushed to our public SDK github repo.

Note that I'll need to rebase the `gminn/lte-metrics` branch of
https://github.com/memfault/sdk-nrf.git to pick up a newer upstream
`main`, which has an updated sha of their Zephyr fork which includes
this commit:

https://github.com/zephyrproject-rtos/zephyr/commit/e7bd10ae719d1773f8d6b189c18f775d9dfcc93d

Otherwise the build fails, because our NCS branch is pointing to a
commit off upstream main that was randomly off Zephyr working main.
