### PR TITLE
Add support for catching faults with TF-M

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,7 +11,7 @@ manifest:
       # TODO: Remove url and revision when this is no
       # longer needed
       url: https://github.com/memfault/sdk-nrf.git
-      revision: gminn/v2.5.0-lte-metrics
+      revision: gminn/v2.5.99-lte-metrics
       import: true
 
     - name: memfault-firmware-sdk


### PR DESCRIPTION
### Summary

Nordic [recently added support for catching faults triggered 
in the SPE](https://github.com/nrfconnect/sdk-nrf/pull/13094). 
This commit is on upstream NCS's main branch, so to pull in the
change, we now have a branch on our NCS fork with lte metrics
rebased on NCS latest.

### Test Plan

Triggered a BusFault via `mflt test busfault` before the change
and confirmed that the reset [showed up in Memfault as a "Software Reset"](https://app.memfault.com/organizations/memfault/projects/thingy91-fleet/devices/351901930733237?series=%5B%22reboot_reasons%22,%5B%22reboots%22%5D%5D&t=1703873440469#timelineState=eyJ2ZXJzaW9uIjoxLCJzd2ltbGFuZXMiOnsib3ZlcmxheSI6eyJtZXRyaWNzIjpbIltcInJlcG9ydHNcIixbXCJuY3NfbHRlX2JhbmRcIl1dIl19fX0%3D).

Then, tried again after pulling in the changes and the reset
[showed up as a HardFault instead](https://app.memfault.com/organizations/memfault/projects/thingy91-fleet/issues/1208264?tab=trace-details) with the following print out in the console:

```
uart:~$ mflt test busfault
[00:00:29.161,743] <err> os: ***** SECURE FAULT *****
[00:00:29.161,773] <err> os:   Invalid entry point
[00:00:29.161,804] <err> os: r0/a1:  0x00000001  r1/a2:  0x2001fba4  r2/a3:  0x2001fba4
[00:00:29.161,804] <err> os: r3/a4:  0x50000001 r12/ip:  0x00070b56 r14/lr:  0x00043073
[00:00:29.161,834] <err> os:  xpsr:  0x61000000
[00:00:29.161,865] <err> os: s[ 0]:  0x0005711f  s[ 1]:  0x000570b5  s[ 2]:  0x0005c254  s[ 3]:  0x0005c254
[00:00:29.161,865] <err> os: s[ 4]:  0x0005d83c  s[ 5]:  0x00000002  s[ 6]:  0x00027ea5  s[ 7]:  0xffee6f78
[00:00:29.161,895] <err> os: s[ 8]:  0x20035f62  s[ 9]:  0x20035f7d  s[10]:  0x00032dab  s[11]:  0x00000000
[00:00:29.161,926] <err> os: s[12]:  0x0005c41c  s[13]:  0x00000000  s[14]:  0x20025378  s[15]:  0x20018874
[00:00:29.161,926] <err> os: fpscr:  0x0005d83c
[00:00:29.161,956] <err> os: r4/v1:  0xe000e000  r5/v2:  0x00000001  r6/v3:  0x00070b56
[00:00:29.161,987] <err> os: r7/v4:  0xfffffffc  r8/v5:  0x2001fba8  r9/v6:  0x0005f478
[00:00:29.162,017] <err> os: r10/v7: 0x00000002  r11/v8: 0x00000000    psp:  0x2001fb28
[00:00:29.162,017] <err> os: EXC_RETURN: 0xffffffbc
[00:00:29.162,048] <err> os: Faulting instruction address (r15/pc): 0x50000000
```

----

Resolves: MFLT-12462
