### PR TITLE
Add workflow to auto-deploy an OTA update

### DIFF
--- a/.github/workflows/ota-deploy.yml
+++ b/.github/workflows/ota-deploy.yml
@@ -58,9 +58,6 @@ jobs:
           west build -b thingy91_nrf9160_ns -p always memfault-asset-tracker -- \
           -DCONFIG_MEMFAULT_NCS_PROJECT_KEY=\"${{ secrets.THINGY91_OTA_PROJECT_KEY }}\" \
           -DOVERLAY_CONFIG=overlay-memfault.conf \
-          -DCONFIG_BUILD_OUTPUT_META=n \
-          -Dmcuboot_CONFIG_BUILD_OUTPUT_META=n \
-          -DCONFIG_NEWLIB_LIBC_FLOAT_PRINTF=y \
           -DCONFIG_MEMFAULT_NCS_FW_VERSION_STATIC=y \
           -DCONFIG_MEMFAULT_NCS_FW_VERSION=\"${{ env.SOFTWARE_VERSION }}\"
 


### PR DESCRIPTION
### Summary

To streamline dog-fooding for this fleet, OTA updates are now triggered
when a push is made to the main branch of this repo.

### Test Plan

Triggered the workflow manually with:

```
gh workflow run ota-deploy.yml --ref gminn/add-auto-ota-deploy
```

which [completed successfully](https://github.com/memfault/memfault-asset-tracker/actions/runs/7450362778/job/20269093522). The [payload](https://app.memfault.com/organizations/memfault/projects/thingy91-fleet/releases/2024.01.08.7450362778) and [symbol file](https://app.memfault.com/organizations/memfault/projects/thingy91-fleet/symbol-files) (build id `9003536c6c192116291d676edf9dcdc79aca5fed`) got uploaded correctly. 
Verified that the ota deploy was successful by verifying my device got the payload
and did a firmware update:

```
*** Booting nRF Connect SDK 2d2da43e7515 ***
[00:00:00.271,545] <inf> mflt: Reset Reason, RESETREAS=0x10000
[00:00:00.271,606] <inf> mflt: Reset Causes:
[00:00:00.271,636] <inf> mflt:  Software
[00:00:00.272,735] <inf> mflt: GNU Build ID: 9003536c6c192116291d676edf9dcdc79aca5fed
[00:00:00.273,101] <inf> mflt: Periodic background upload scheduled - duration=4611s period=10800s
...
uart:~$ mflt get_device_info
[00:08:20.264,801] <inf> mflt: S/N: 351901930733237
[00:08:20.264,892] <inf> mflt: SW type: nrf91ns-fw
[00:08:20.264,953] <inf> mflt: SW version: 2024.01.08.7450362778
[00:08:20.264,984] <inf> mflt: HW version: thingy91
```

----
Resolves: MFLT-12995