### PR TITLE
Update to Memfault SDK 1.6.1

### DIFF
--- a/overlay-memfault.conf
+++ b/overlay-memfault.conf
@@ -42,7 +42,3 @@ CONFIG_MEMFAULT_FOTA=y
 
 CONFIG_MEMFAULT_NCS_FW_VERSION_STATIC=y
 CONFIG_MEMFAULT_NCS_FW_VERSION="0.0.99-dev"
-
-# TODO: Remove after disabling just the self-test
-# Disable shell to save space
-CONFIG_MEMFAULT_SHELL=n

--- a/west.yml
+++ b/west.yml
@@ -17,7 +17,7 @@ manifest:
     - name: memfault-firmware-sdk
       url: https://github.com/memfault/memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: "1.6.0"
+      revision: "1.6.1"
 
   self:
     path: firmware


### PR DESCRIPTION
Required rebasing the sdk-nrf fork branch, because the
`fota_download_any()` API is present in the 2.5.99 upstream `main`, to
be released in 2.6.0, and the version check assumes 2.5.99==2.6.0. We
only in practice support real NCS releases.

I verified flashing this build is able to OTA.