### PR TITLE
chore(ncs): point to new dogfood branch on NCS fork

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,7 +11,7 @@ manifest:
       # TODO: Remove url and revision when this is no
       # longer needed
       url: https://github.com/memfault/sdk-nrf.git
-      revision: gminn/v2.5.99-lte-metrics
+      revision: dogfood
       import: true
 
     - name: memfault-firmware-sdk


### PR DESCRIPTION
### Summary

Per our new [NCS contribution workflow](https://www.notion.so/memfault/New-NCS-Contribution-Workflow-b8cebfdb81524baeadd79da0c9443eaf?pvs=4), we are now using the branch
`dogfood` on our fork of NCS to test our SDK + this curated app against.

### Internal Documentation

This branch was branch from `gminn/v2.5.0-lte-metrics`, and then `main` was synced from
upstream main, and merged in.

```
git checkout main
git pull main
git checkout gminn/v2.5.0-lte-metrics
git pull
git checkout -b dogfood
git merge main
# resolve merge conflicts
git commit -m "Merge branch 'main' into dogfood"
```

Then double-checked that there were no differences between `main` and `dogfood`.

```
> git checkout dogfood
Already on 'dogfood'
> git diff main
# no difference
>
```

### Test Plan

CI passes.