### PR TITLE
fix(coredump): increase ram-backed coredump size

### DIFF
--- a/overlay-memfault.conf
+++ b/overlay-memfault.conf
@@ -16,6 +16,8 @@ CONFIG_MEMFAULT_ROOT_CERT_STORAGE_NRF9160_MODEM=y
 CONFIG_MEMFAULT_NCS_PROVISION_CERTIFICATES=n
 CONFIG_MODEM_KEY_MGMT=y
 
+# Increase the coredump size to be able to capture all thread stacks
+CONFIG_MEMFAULT_RAM_BACKED_COREDUMP_SIZE=10240
 CONFIG_MEMFAULT_COREDUMP_COLLECT_BSS_REGIONS=y
 
 # Increase the stack size of the system workqueue in case Memfault is enabled. If the debug module


### PR DESCRIPTION
### Summary

We need a bigger ram-backed coredump in order to capture all
thread stacks. Bump it up 2kB to be safe.

### Internal Documentation

https://memfault.slack.com/archives/C04SJUGE9GA/p1706015927197819

### Test Plan

With smaller coredump:

https://app.memfault.com/organizations/memfault/projects/gilly-thingy91-playground/issues/1223827/traces/4113040084?tab=trace-details

With bigger coredump:

https://app.memfault.com/organizations/memfault/projects/gilly-thingy91-playground/issues/1223827/traces/4115258742?tab=trace-details

---

Context: MCU-158