### PR TITLE
chore(action): rename github action workflow file

### DIFF
--- a/.github/workflows/ota-deploy.yaml
+++ b/.github/workflows/ota-deploy.yaml
@@ -1,4 +1,4 @@
-name: WeFault Fleet Build & OTA Deploy
+name: Build & OTA Deploy
 run-name: ${{ inputs.run_name }}
 
 env:

--- a/README.md
+++ b/README.md
@@ -68,4 +68,4 @@ west flash --erase
 ## Deploying OTAs
 
 This app also has an example of how to auto-deploy releases with Memfault.
-See [`ota-deploy.yml`](.github/workflows/ota-deploy.yaml).
+See [`ota-deploy.yaml`](.github/workflows/ota-deploy.yaml).


### PR DESCRIPTION
## Summary

Rename the OTA deploy workflow file extention to match the other workflow files.
Also remove reference to wefault in the workflow title.

## Test Plan

Checked that link in readme now works.