### PR TITLE
chore(memfault): add gh action to pull in latest memfault

### DIFF
--- a/.github/workflows/update-memfault.yaml
+++ b/.github/workflows/update-memfault.yaml
@@ -1,0 +1,59 @@
+name: Update Memfault
+run-name: ${{ inputs.run_name }}
+
+env:
+  DEFAULT_PYTHON: 3.8
+
+on:
+  schedule:
+    - cron: "8 0 * * *"
+  workflow_dispatch:
+    inputs:
+      run_name:
+        description: 'Name of run to identify it from other runs'
+        required: false
+        type: string
+
+jobs:
+  update-memfault:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install needed packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y -qq \
+          curl \
+          ripgrep
+
+      - name: Check for outdated SDK version
+        run: |
+          LATEST_SDK_VER=$(rg 'VERSION:\s(\d+\.\d+\.\d+)' \
+            <(curl -sSL 'https://raw.githubusercontent.com/memfault/memfault-firmware-sdk/master/VERSION') -r '$1' --no-filename --no-line-number)
+          REPO_SDK_VER=$(yq '.manifest.projects[1].revision' west.yml)
+          echo "LATEST_SDK_VER=$LATEST_SDK_VER" >> $GITHUB_ENV
+          echo "REPO_SDK_VER=$REPO_SDK_VER" >> $GITHUB_ENV
+
+      - name: Update west.yml
+        if: ${{ env.REPO_SDK_VER != env.LATEST_SDK_VER }}
+        run: |
+          yq -i '.manifest.projects[1].revision = "${{ env.LATEST_SDK_VER }}"' west.yml
+          git status
+
+      - name: Create Pull Request
+        if: ${{ env.REPO_SDK_VER != env.LATEST_SDK_VER }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GH_PAT }}
+          commit-message: |
+            chore(memfault): update memfault sdk
+          body: |
+            Update the Memfault SDK to ${{ env.LATEST_SDK_VER }}.
+          title: |
+            chore(memfault): update memfault sdk
+          base: main
+          branch: github-actions/update-to-memfault-v${{ env.LATEST_SDK_VER }}
+          delete-branch: true
+          team-reviewers: memfault/owners-mcu


### PR DESCRIPTION
### Summary

To exercise the latest changes in the Memfault SDK,
the Memfault bot will now open a PR for us when there is a
new SDK release. We'll check daily for a new version
with this new GH action.

The `delete-branch` setting on the create PR step means
that if the SDK version ended up getting updated on `main`
after the bot opened a PR for it, it will delete the branch on the
next run of the action since it isn't needed, closing the PR in the
process.

### Test Plan

- Test action when SDK version is out of date

```
gh workflow run update-memfault.yaml --ref gminn/action-to-get-memfault-latest
```

Resulting PR [here](https://github.com/memfault/memfault-asset-tracker/pull/37) and action results [here](https://github.com/memfault/memfault-asset-tracker/actions/runs/8176412583/job/22355738374)!

- Test action when SDK version is not out of date

Created a branch off this branch with the new action and the SDK updated to 1.7.1. 

```
gh workflow run update-memfault.yaml --ref gminn/test-up-to-date-sdk-ver
```

Action results [here](https://github.com/memfault/memfault-asset-tracker/actions/runs/8176427061/job/22355788792) showing the skipped steps.

- Test action when a PR is currently open for the SDK version change

Action results [here](https://github.com/memfault/memfault-asset-tracker/actions/runs/8176438022/job/22355830130#step:6:943). It finds that a PR already exists and attempts to update it but nothing has changed.