### PR TITLE
fix(build): enable non-memfault builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,18 +35,25 @@ jobs:
         run: |
           ${ZEPHYR_SDK_INSTALL_DIR}/setup.sh -c
 
-      - name: Build app
+      - name: Build app without Memfault overlay
         run: |
           cd $GITHUB_WORKSPACE
           cd ../
           python -m venv venv
           . venv/bin/activate
           pip install -U pip==21.1
-          pip install west==1.2.0 memfault-cli==1.0.4
+          pip install west==1.2.0
           west init -l memfault-asset-tracker
           west update --narrow -o=--depth=1 -o=--recurse-submodules --path-cache ~/zephyr-thingy91-path-cache
           pip install -r zephyr/scripts/requirements.txt
           pip install -r nrf/scripts/requirements-build.txt
+          west build -b thingy91_nrf9160_ns -p always memfault-asset-tracker
+
+      - name: Build app with Memfault overlay
+        run: |
+          cd $GITHUB_WORKSPACE
+          cd ../
+          . venv/bin/activate
           west build -b thingy91_nrf9160_ns -p always memfault-asset-tracker -- \
           -DCONFIG_MEMFAULT_NCS_PROJECT_KEY=\"DUMMY_KEY\" \
           -DOVERLAY_CONFIG=overlay-memfault.conf \

--- a/overlay-memfault.conf
+++ b/overlay-memfault.conf
@@ -47,3 +47,7 @@ CONFIG_MEMFAULT_NCS_FW_VERSION="0.0.99-dev"
 
 # Define our own implementation of this function
 CONFIG_MEMFAULT_NCS_IMPLEMENT_METRICS_COLLECTION=n
+
+# Let's manage the memfault_fota_download_callback() from
+# the asset tracker application rather than using the Memfault default
+CONFIG_MEMFAULT_FOTA_DOWNLOAD_CALLBACK_CUSTOM=y

--- a/prj.conf
+++ b/prj.conf
@@ -126,7 +126,3 @@ CONFIG_LOG_DEFAULT_LEVEL=3
 # instead of logs being separately viewed in a file via
 # RTT logger
 CONFIG_SHELL_LOG_BACKEND=y
-
-# Let's manage the memfault_fota_download_callback() from
-# the asset tracker application rather than using the Memfault default
-CONFIG_MEMFAULT_FOTA_DOWNLOAD_CALLBACK_CUSTOM=y

--- a/src/main.c
+++ b/src/main.c
@@ -25,8 +25,10 @@
 #include "events/util_module_event.h"
 #include "events/modem_module_event.h"
 
+#if defined(CONFIG_MEMFAULT)
 #include "memfault/components.h"
 #include "memfault/nrfconnect_port/fota.h"
+#endif
 
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_ctrl.h>


### PR DESCRIPTION
### Summary

 A build warning + error pop up if building without Memfault. This
 commit makes a few changes to ensure this app still builds even if
 `overlay-memfault.conf` is not used in the build.

 ### Test Plan

 - CI
 - Builds without error when running just:

 ```
 west build -b thingy91_nrf9160_ns -p always memfault-asset-tracker
 ```