### PR TITLE
fix(fota): remove custom download callback

### DIFF
--- a/overlay-memfault.conf
+++ b/overlay-memfault.conf
@@ -48,7 +48,3 @@ CONFIG_MEMFAULT_NCS_FW_VERSION="0.0.99-dev"
 
 # Define our own implementation of this function
 CONFIG_MEMFAULT_NCS_IMPLEMENT_METRICS_COLLECTION=n
-
-# Let's manage the memfault_fota_download_callback() from
-# the asset tracker application rather than using the Memfault default
-CONFIG_MEMFAULT_FOTA_DOWNLOAD_CALLBACK_CUSTOM=y

--- a/src/main.c
+++ b/src/main.c
@@ -522,21 +522,6 @@ static void prv_run_memfault_fota_check(void) {
 	k_work_schedule(&s_memfault_fota_work, K_SECONDS(FOTA_WORK_ITEM_DELAY_SECONDS));
 }
 
-void memfault_fota_download_callback(const struct fota_download_evt *evt)
-{
-	switch (evt->id) {
-	case FOTA_DOWNLOAD_EVT_FINISHED:
-		MEMFAULT_LOG_INFO("OTA Complete, resetting to install update!");
-		memfault_platform_reboot();
-		break;
-	case FOTA_DOWNLOAD_EVT_ERROR:
-		MEMFAULT_LOG_ERROR("FOTA failed");
-		break;
-	default:
-		break;
-	}
-}
-
 static void prv_memfault_fota_timer_expiry_handler(struct k_timer *timer)
 {
 	ARG_UNUSED(timer);


### PR DESCRIPTION
### Summary

 Since removing the custom retry logic from our OTA hack, we no longer
 need to use a custom download callback. This change removes the custom
 download callback and uses the default download callback provided by
 the Memfault SDK.

 ### Test Plan

 Triggered a FOTA update from a thingy91 device and confirmed that the
 FOTA worked successfully.

---

Resolves: MCU-306